### PR TITLE
Make the list of keys to encrypt with accurate

### DIFF
--- a/lib/hiera/backend/eyaml/encryptors/gpg.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gpg.rb
@@ -109,7 +109,7 @@ class Hiera
 
               unless recipient_file.nil?
                 recipient_file.readlines.map{ |line|
-                  line.strip unless line.start_with? '#'
+                  line.strip unless line.start_with? '#' or line.strip.empty?
                 }.compact
               else
                 []


### PR DESCRIPTION
If the recipients file had a blank line or line with just whitespace it
would result in the first key from the local key chain being added to
the list of keys to be used for encryption making the resultant file not
as secure as thought.

From https://github.com/hmrc/hiera-eyaml-gpg/commit/fda0ea7a717424620024bb3612fcc68bb9efef9a